### PR TITLE
(branch gamer) 使pre, code, kbd, tt, var元素使用等宽字体(--ofcodetext)

### DIFF
--- a/blackout-gamer.css
+++ b/blackout-gamer.css
@@ -394,7 +394,7 @@ kbd,
 tt,
 var {
     font-size: 0.875em;
-    font-family: var(--text-font);
+    font-family: var(--ofcodetext);
 }
 
 code,


### PR DESCRIPTION
在macOS系统上（其他系统上不确定，但应该也是这样），使用“\`\`”显示出的`像这样`引用的内联代码会使用默认字体（即`--text-font`字体集）显示，不符合其本身含义。由此提交PR😃