### PR TITLE
fix: 修复菜单栏导出项详情页面背景不一致问题

### DIFF
--- a/blackout.css
+++ b/blackout.css
@@ -1352,11 +1352,13 @@ footer.ty-footer {
     height: 21px;
 }
 
-.ty-preferences .nav-group-item.active,
+.ty-preferences .nav-group-item.active{
+    background: var(--item-hover-bg-color);
+}
 .export-item.active,
 .export-items-list-control,
 .export-detail {
-    background: var(--item-hover-bg-color);
+    background: transparent !important;
 }
 
 .ty-preferences input[type="search"] {


### PR DESCRIPTION
修复前：
![image](https://github.com/user-attachments/assets/fede28ea-cb5b-41e0-8e98-77311822fe8a)

修复后：
![image](https://github.com/user-attachments/assets/d3821455-2fa2-42b2-96a2-14552cf4e82d)
